### PR TITLE
Ensure 64-bit memory addresses are displayed

### DIFF
--- a/UEDumper/Engine/Core/EngineStructs.h
+++ b/UEDumper/Engine/Core/EngineStructs.h
@@ -285,7 +285,7 @@ namespace EngineStructs
 	{
 		Struct* owningStruct = nullptr; //the struct this function resides in
 		int owningVectorIndex = 0; //the vector index this function resides in
-		uintptr_t memoryAddress;
+               uint64_t memoryAddress;
 		fieldType returnType;
 		std::vector<std::tuple<fieldType, std::string, uint64_t, uint64_t>> params; //fieldType, name, propertyFlags, arrayDim
 		std::string fullName;
@@ -332,7 +332,7 @@ namespace EngineStructs
 		Package* owningPackage = nullptr; //the package this struct resides in
 		int owningVectorIndex = 0; //the vector index this struct resides in
 		bool isClass = false; //if struct is actually a class. Even if we have in packages a struct and class vector, every struct should know what it is
-		uintptr_t memoryAddress = 0; //the real memory address where the struct is
+               uint64_t memoryAddress = 0; //the real memory address where the struct is
 		std::string fullName; //the full name of the struct
 		std::string cppName; //the cppName of the struct
 		std::vector<std::string> superNames{}; //all the structs it inherits, empty, only used in package generation
@@ -420,7 +420,7 @@ namespace EngineStructs
 	{
 		Package* owningPackage = nullptr;
 		int owningVectorIndex = 0;
-		uintptr_t memoryAddress;
+               uint64_t memoryAddress;
 		std::string fullName;
 		std::string cppName;
 		std::string type;

--- a/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
+++ b/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
@@ -2,6 +2,7 @@
 #include "EditWindow.h"
 #include "LogWindow.h"
 #include "Engine/Core/Core.h"
+#include "Memory/Memory.h"
 #include "Frontend/IGHelper.h"
 #include "Frontend/Fonts/fontAwesomeHelper.h"
 #include "Frontend/Texture/TextureCreator.h"
@@ -79,7 +80,7 @@ void windows::PackageViewerWindow::renderClassOrStruct(PackageTab* tab, EngineSt
     ImGui::SameLine();
     //render some infos in green
     ImGui::PushStyleColor(ImGuiCol_Text, IGHelper::Colors::commentGreen);
-    ImGui::Text("Memory address: 0x%p", struc.memoryAddress);
+    ImGui::Text("Memory address: 0x%llX", struc.memoryAddress);
     if (struc.isClass)
         ImGui::Text("Class index: %d", struc.owningVectorIndex);
     else
@@ -275,7 +276,7 @@ void windows::PackageViewerWindow::renderEnum(const EngineStructs::Enum& enu)
     }
     ImGui::SameLine();
     ImGui::PushStyleColor(ImGuiCol_Text, IGHelper::Colors::commentGreen);
-    ImGui::Text("Memory address: 0x%p", enu.memoryAddress);
+    ImGui::Text("Memory address: 0x%llX", enu.memoryAddress);
     ImGui::Text("Enum index: %d", enu.owningVectorIndex);
 
     ImGui::Text("Items: %d", enu.members.size());
@@ -324,7 +325,10 @@ void windows::PackageViewerWindow::renderFunction(const EngineStructs::Function&
     copyToClipBoard(reinterpret_cast<uint64_t>(&func.memoryAddress));
     ImGui::SameLine();
     ImGui::PushStyleColor(ImGuiCol_Text, IGHelper::Colors::commentGreen);
-    ImGui::Text("Memory address: 0x%p", func.memoryAddress);
+    ImGui::Text("Memory address: 0x%llX", func.memoryAddress);
+    copyToClipBoard(Memory::getBaseAddress() + func.binaryOffset);
+    ImGui::SameLine();
+    ImGui::Text("Function address in Binary: 0x%llX", Memory::getBaseAddress() + func.binaryOffset);
     ImGui::Text("Function index: %d", func.owningVectorIndex);
     ImGui::PopStyleColor();
     copyToClipBoard(func.binaryOffset);


### PR DESCRIPTION
## Summary
- store struct, enum and function memory addresses as 64-bit values
- show real memory locations and function addresses in PackageViewer

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_6896fb8677248330ae00bebb46d12391