### PR TITLE
Add Cheat Engine export capability

### DIFF
--- a/UEDumper/Engine/Generation/CEExporter.cpp
+++ b/UEDumper/Engine/Generation/CEExporter.cpp
@@ -1,0 +1,40 @@
+#include "CEExporter.h"
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace {
+    std::string escapeXml(const std::string& str) {
+        std::string out;
+        out.reserve(str.size());
+        for (char c : str) {
+            switch (c) {
+            case '&': out += "&amp;"; break;
+            case '"': out += "&quot;"; break;
+            case '\'': out += "&apos;"; break;
+            case '<': out += "&lt;"; break;
+            case '>': out += "&gt;"; break;
+            default: out += c; break;
+            }
+        }
+        return out;
+    }
+}
+
+void CEExporter::exportToCheatEngine(const EngineStructs::Struct& s, const std::string& filePath) {
+    std::ostringstream xml;
+    xml << "<CheatTable><Structures>";
+    xml << "<Structure Name=\"" << escapeXml(s.cppName) << "\"><Elements>";
+    for (const auto& member : s.definedMembers) {
+        xml << "<Element Offset=\"" << member.offset << "\" Description=\"" << escapeXml(member.name)
+            << "\" Type=\"" << escapeXml(member.type.name) << "\"/>";
+    }
+    xml << "</Elements></Structure></Structures></CheatTable>";
+
+    std::filesystem::path path(filePath);
+    std::filesystem::create_directories(path.parent_path());
+
+    std::ofstream out(filePath, std::ios::binary);
+    out << xml.str();
+}
+

--- a/UEDumper/Engine/Generation/CEExporter.h
+++ b/UEDumper/Engine/Generation/CEExporter.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "stdafx.h"
+#include "Engine/Core/EngineStructs.h"
+
+namespace CEExporter {
+    void exportToCheatEngine(const EngineStructs::Struct& s, const std::string& filePath);
+}
+

--- a/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
+++ b/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
@@ -6,6 +6,8 @@
 #include "Frontend/IGHelper.h"
 #include "Frontend/Fonts/fontAwesomeHelper.h"
 #include "Frontend/Texture/TextureCreator.h"
+#include "Engine/Generation/CEExporter.h"
+#include <filesystem>
 
 
 void windows::PackageViewerWindow::renderSubTypes(const fieldType& type, bool inChild)
@@ -76,6 +78,15 @@ void windows::PackageViewerWindow::renderClassOrStruct(PackageTab* tab, EngineSt
         sprintf_s(address, "0x%llX", struc.memoryAddress);
         IGHelper::copyToClipBoard(std::string(address));
         LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGEVIEWER", "Copied address to clipboard!");
+    }
+    ImGui::SameLine();
+    if (ImGui::Button(merge(ICON_FA_DOWNLOAD, " Export to CE")))
+    {
+        CEExporter::exportToCheatEngine(struc, "Resources/CEExports/selected.ct");
+        if (std::filesystem::exists("Resources/CEExports/selected.ct"))
+            LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGEVIEWER", "Exported struct to Cheat Engine");
+        else
+            LogWindow::Log(LogWindow::logLevels::LOGLEVEL_ERROR, "PACKAGEVIEWER", "Failed to export struct to Cheat Engine");
     }
     ImGui::SameLine();
     //render some infos in green

--- a/UEDumper/UEDumper.vcxproj
+++ b/UEDumper/UEDumper.vcxproj
@@ -154,6 +154,7 @@
   <ItemGroup>
     <ClCompile Include="Engine\Core\Core.cpp" />
     <ClCompile Include="Engine\Core\ObjectsManager.cpp" />
+    <ClCompile Include="Engine\Generation\CEExporter.cpp" />
     <ClCompile Include="Engine\Generation\MDK.cpp" />
     <ClCompile Include="Engine\Generation\SDK.cpp" />
     <ClCompile Include="Engine\Live\LiveMemory.cpp" />
@@ -189,6 +190,7 @@
     <ClInclude Include="Engine\Core\ObjectsManager.h" />
     <ClInclude Include="Engine\enums.h" />
     <ClInclude Include="Engine\Generation\BasicType.h" />
+    <ClInclude Include="Engine\Generation\CEExporter.h" />
     <ClInclude Include="Engine\Generation\MDK.h" />
     <ClInclude Include="Engine\Generation\packageSorter.h" />
     <ClInclude Include="Engine\Generation\SDK.h" />

--- a/UEDumper/UEDumper.vcxproj.filters
+++ b/UEDumper/UEDumper.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="Engine\Generation\MDK.cpp">
       <Filter>Engine\Generation</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Generation\CEExporter.cpp">
+      <Filter>Engine\Generation</Filter>
+    </ClCompile>
     <ClCompile Include="Resources\Dumpspace\dumpspace.cpp">
       <Filter>Resources\Dumpspace</Filter>
     </ClCompile>
@@ -282,6 +285,9 @@
       <Filter>Resources\Dumpspace</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Generation\packageSorter.h">
+      <Filter>Engine\Generation</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Generation\CEExporter.h">
       <Filter>Engine\Generation</Filter>
     </ClInclude>
     <ClInclude Include="Frontend\StrucGraph.h">


### PR DESCRIPTION
## Summary
- add CEExporter module to generate Cheat Engine XML for a selected struct
- hook PackageViewer export button to CE exporter and log results
- register new files in project files

## Testing
- `dotnet build UEDumper.sln` *(fails: command not found)*
- `msbuild UEDumper.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689701470a608330982cccff9227fcd5