### PR TITLE
Fix Cheat Engine export to use CES structure format

### DIFF
--- a/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
+++ b/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
@@ -82,8 +82,8 @@ void windows::PackageViewerWindow::renderClassOrStruct(PackageTab* tab, EngineSt
     ImGui::SameLine();
     if (ImGui::Button(merge(ICON_FA_DOWNLOAD, " Export to CE")))
     {
-        CEExporter::exportToCheatEngine(struc, "Resources/CEExports/selected.ct");
-        if (std::filesystem::exists("Resources/CEExports/selected.ct"))
+        CEExporter::exportToCheatEngine(struc, "Resources/CEExports/selected.ces");
+        if (std::filesystem::exists("Resources/CEExports/selected.ces"))
             LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGEVIEWER", "Exported struct to Cheat Engine");
         else
             LogWindow::Log(LogWindow::logLevels::LOGLEVEL_ERROR, "PACKAGEVIEWER", "Failed to export struct to Cheat Engine");


### PR DESCRIPTION
## Summary
- Export Cheat Engine structures using .CES schema with proper vartype mapping and attributes
- Update package viewer to generate `.ces` files

## Testing
- `x86_64-w64-mingw32-g++ -std=c++20 -I. -IFrontend/ImGui -IEngine -IEngine/Core -IEngine/Userdefined -IResources/Json -c Engine/Generation/CEExporter.cpp`
- `x86_64-w64-mingw32-g++ -std=c++20 -I. -IFrontend/ImGui -IEngine -IEngine/Core -IEngine/Userdefined -IResources/Json -c Frontend/Windows/PackageViewerWindow.cpp` *(fails: default member initializer ... required before end of its enclosing class)*

------
https://chatgpt.com/codex/tasks/task_e_68970854cfd883308426741a0c9a25de