### PR TITLE
Fix std::max macro conflict

### DIFF
--- a/UEDumper/Engine/Generation/CEExporter.cpp
+++ b/UEDumper/Engine/Generation/CEExporter.cpp
@@ -7,6 +7,13 @@
 #include <vector>
 #include "Frontend/Windows/LogWindow.h"
 
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+
 namespace {
     std::string escapeXml(const std::string& str) {
         std::string out;


### PR DESCRIPTION
## Summary
- avoid Windows macro collisions in CEExporter by undefining min/max

## Testing
- `g++ -std=c++17 -I UEDumper -c UEDumper/Engine/Generation/CEExporter.cpp` *(fails: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897e927008c83309f08e092d6533fd1