### PR TITLE
Support runtime custom classes in live editor

### DIFF
--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -1123,13 +1123,31 @@ std::vector<EngineStructs::Package>& EngineCore::getPackages()
 }
 
 
-const ObjectInfo* EngineCore::getInfoOfObject(const std::string & CName)
+const ObjectInfo* EngineCore::getInfoOfObject(const std::string& CName)
 {
-	//in functions we compare packageIndex and objectIndex anyways so the type doesnt matter
-	if (!packageObjectInfos.contains(CName))
-		return nullptr;
+        return getInfoOfObject(CName, nullptr);
+}
 
-	return &packageObjectInfos[CName];
+const ObjectInfo* EngineCore::getInfoOfObject(const std::string& CName, UStruct* uStruct)
+{
+        if (!packageObjectInfos.contains(CName) && uStruct)
+        {
+                const std::string className = uStruct->getCName();
+                if (!packageObjectInfos.contains(className))
+                {
+                        if (generateStructOrClass(uStruct, customStructs))
+                        {
+                                auto& struc = customStructs.back();
+                                struc.isClass = uStruct->IsA<UClass>();
+                                packageObjectInfos.insert(std::pair(struc.cppName, ObjectInfo(true, struc.isClass ? ObjectInfo::OI_Class : ObjectInfo::OI_Struct, &customStructs.back())));
+                        }
+                }
+        }
+
+        if (!packageObjectInfos.contains(CName))
+                return nullptr;
+
+        return &packageObjectInfos[CName];
 }
 
 

--- a/UEDumper/Engine/Core/Core.h
+++ b/UEDumper/Engine/Core/Core.h
@@ -159,7 +159,8 @@ public:
 	 * \param CName CName  of the UObject
 	 * \return ObjectInfo of the UObject
 	 */
-	static const ObjectInfo* getInfoOfObject(const std::string& CName);
+        static const ObjectInfo* getInfoOfObject(const std::string& CName);
+        static const ObjectInfo* getInfoOfObject(const std::string& CName, UStruct* uStruct);
 
 
 


### PR DESCRIPTION
## Summary
- generate struct info at runtime when a class is missing from cached packages
- use class pointers to build definitions in the live editor

## Testing
- `g++ -fsyntax-only UEDumper/Engine/Core/Core.cpp UEDumper/Frontend/Windows/LiveEditor.cpp` *(fails: stdafx.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899a68789848330963a9ed747004674